### PR TITLE
chore: add missing Google API dependencies to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,8 @@ python-dotenv
 openai
 aiohttp
 requests
+google-api-python-client
+google-auth
+google-auth-httplib2
+google-auth-oauthlib
+pytz


### PR DESCRIPTION
- Added `google-api-python-client`, `google-auth`, `google-auth-httplib2`, 
  `google-auth-oauthlib`, and `pytz` to requirements.txt
- Fixed formatting issue where `requests` and `google-api-python-client` 
  were accidentally combined into one line.
- Ensures `pip install -r requirements.txt` installs everything needed 
  as per INSTALLATION.md and actual code usage.
closes #4 